### PR TITLE
Enable setzer to handle multiple nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # INSTALLATION
 
-   |                |                                        |
+   | command        |  description                           |
    |----------------|----------------------------------------| 
    |`make link`     |  install setzer(1) into `/usr/local`   |  
    |`make uninstall`|  uninstall setzer(1) from `/usr/local` |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@
    `make link`       install setzer(1) into /usr/local  
    `make uninstall`  uninstall setzer(1) from /usr/local
 # SETUP
-   
+  setzer expects a `/etc/setzer.conf` file that looks like this:
+
+```bash
+  export ETH_FROM="YOUR ACCOUNT"
+  export SETZER_FEED="YOUR PRICE-FEED ADDRESS"
+  export SETZER_MEDIANIZER="0x729D19f657BD0614b4985Cf1D82531c67569197B"
+  export SETZER_SOURCES="LIST OF PRICE SOURCES"
+  
+  #LIST OF RPC PORTS TO CONNECT TO
+  export RPC_PORTS="8545"
+  
+  #TIME TO WAIT FOR A NODE TO RESPOND
+  export RPC_TIMEOUT=5s
+```
 # DEPENDENCIES
    seth(1)         https://github.com/dapphub/seth  
    curl(1)         https://curl.haxx.se/  

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
    `setzer <command> --help`
 
 # INSTALLATION
-   
+
+   |                |                                        |
+   |----------------|----------------------------------------| 
    |`make link`     |  install setzer(1) into `/usr/local`   |  
    |`make uninstall`|  uninstall setzer(1) from `/usr/local` |
+
 # SETUP
   setzer expects a `/etc/setzer.conf` file that looks like this:
 

--- a/README.md
+++ b/README.md
@@ -2,39 +2,39 @@
    setzer -- manipulate feeds and update data
 
 # SYNOPSIS
-   setzer <command> [<args>]
-   setzer <command> --help
+   setzer \<command> [\<args>]  
+   setzer \<command> --help
 
 # INSTALLATION
-   make link       install setzer(1) into /usr/local
+   make link       install setzer(1) into /usr/local  
    make uninstall  uninstall setzer(1) from /usr/local
 
 # DEPENDENCIES
-   seth(1)         https://github.com/dapphub/seth
-   curl(1)         https://curl.haxx.se/
+   seth(1)         https://github.com/dapphub/seth  
+   curl(1)         https://curl.haxx.se/  
    jshon(1)        https://github.com/mbrock/jshon/
 
 # COMMANDS
-   average         get average price of 2 or more price <source>
-   bot             really cool bot
-   compute         get what the medianizer value would be if updated
-   expires         get expiration in seconds (< 0 means expired)
-   help            print help about setzer(1) or one of its subcommands
-   peek            peek a dsvalue, dscache or medianizer
-   poke            poke a medianizer
-   poker           update a poker
-   post            update a ds-price
-   price           show ETH/USD price from <source>
-   prod            update a ds-cache
-   read            read a dsvalue, dscache or medianizer
-   set             set next feed of a medianizer
-   spread          variance of 2 values in %
-   valid           check if a dsvalue, dscache or medianizer has a value
-   void            invalidate a feed
-   volume          show ETH/USD volume from <source>
+   average         get average price of 2 or more price <source>  
+   bot             really cool bot  
+   compute         get what the medianizer value would be if updated  
+   expires         get expiration in seconds (< 0 means expired)  
+   help            print help about setzer(1) or one of its subcommands  
+   peek            peek a dsvalue, dscache or medianizer  
+   poke            poke a medianizer  
+   poker           update a poker  
+   post            update a ds-price  
+   price           show ETH/USD price from <source>  
+   prod            update a ds-cache  
+   read            read a dsvalue, dscache or medianizer  
+   set             set next feed of a medianizer  
+   spread          variance of 2 values in %  
+   valid           check if a dsvalue, dscache or medianizer has a value  
+   void            invalidate a feed  
+   volume          show ETH/USD volume from <source>  
 
 # OPTIONS
-   You can provide any `seth` option to commands that send transactions.
+   You can provide any `seth` option to commands that send transactions.  
    For example `setzer void <feed> -F <account> --gas=100000 -P 1000000000`
 
 Report bugs to <https://github.com/makerdao/setzer/issues>.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NAME
-   setzer -- manipulate feeds and update data
+   `setzer` -- manipulate feeds and update data
 
 # SYNOPSIS
    `setzer <command> [<args>]`  
@@ -8,14 +8,15 @@
 # INSTALLATION
    `make link`       install setzer(1) into /usr/local  
    `make uninstall`  uninstall setzer(1) from /usr/local
-
+# SETUP
+   
 # DEPENDENCIES
    seth(1)         https://github.com/dapphub/seth  
    curl(1)         https://curl.haxx.se/  
    jshon(1)        https://github.com/mbrock/jshon/
 
 # COMMANDS
-   `average`         get average price of 2 or more price <source>  
+   `average`|         get average price of 2 or more price <source>  
    `bot`             really cool bot  
    `compute`         get what the medianizer value would be if updated  
    `expires`         get expiration in seconds (< 0 means expired)  

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
    `setzer <command> --help`
 
 # INSTALLATION
-   `make link`       install setzer(1) into /usr/local  
-   `make uninstall`  uninstall setzer(1) from /usr/local
+   
+   |`make link`     |  install setzer(1) into `/usr/local`   |  
+   |`make uninstall`|  uninstall setzer(1) from `/usr/local` |
 # SETUP
   setzer expects a `/etc/setzer.conf` file that looks like this:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # INSTALLATION
 
-   | command        |  description                           |
+   |                |                                        |
    |----------------|----------------------------------------| 
    |`make link`     |  install setzer(1) into `/usr/local`   |  
    |`make uninstall`|  uninstall setzer(1) from `/usr/local` |

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-NAME
+# NAME
    setzer -- manipulate feeds and update data
 
-SYNOPSIS
+# SYNOPSIS
    setzer <command> [<args>]
    setzer <command> --help
 
-INSTALLATION
+# INSTALLATION
    make link       install setzer(1) into /usr/local
    make uninstall  uninstall setzer(1) from /usr/local
 
-DEPENDENCIES
+# DEPENDENCIES
    seth(1)         https://github.com/dapphub/seth
    curl(1)         https://curl.haxx.se/
    jshon(1)        https://github.com/mbrock/jshon/
 
-COMMANDS
+# COMMANDS
    average         get average price of 2 or more price <source>
    bot             really cool bot
    compute         get what the medianizer value would be if updated
@@ -33,7 +33,7 @@ COMMANDS
    void            invalidate a feed
    volume          show ETH/USD volume from <source>
 
-OPTIONS
+# OPTIONS
    You can provide any `seth` option to commands that send transactions.
    For example `setzer void <feed> -F <account> --gas=100000 -P 1000000000`
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@
   
   #setzer can connect to multiple nodes listed here
   #Space separated list of nodes' rpc ports to connect to
+  #default 8545
   export RPC_PORTS="8545"
   
   #Time to wait for a node to respond
-  export RPC_TIMEOUT=5s
+  #defaults to 15s
+  export RPC_TIMEOUT=15s
 ```
 # DEPENDENCIES
    seth(1)         https://github.com/dapphub/seth  

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@
   export ETH_FROM="YOUR ACCOUNT"
   export SETZER_FEED="YOUR PRICE-FEED ADDRESS"
   export SETZER_MEDIANIZER="0x729D19f657BD0614b4985Cf1D82531c67569197B"
+  
+  #The list of price sources. Execute 'setzer price'
   export SETZER_SOURCES="LIST OF PRICE SOURCES"
   
-  #LIST OF RPC PORTS TO CONNECT TO
+  #setzer can connect to multiple nodes listed here
+  #Space separated list of nodes' rpc ports to connect to
   export RPC_PORTS="8545"
   
-  #TIME TO WAIT FOR A NODE TO RESPOND
+  #Time to wait for a node to respond
   export RPC_TIMEOUT=5s
 ```
 # DEPENDENCIES
@@ -30,9 +33,9 @@
 
 # COMMANDS
 
-  | command    |     description                                            |
+  | command    |      description                                           |
   |------------|------------------------------------------------------------|
-  |`average`   |      get average price of 2 or more price \<source>        |
+  |`average`   |      get average price of 2 or more price `<source>`       |
   |`bot`       |      really cool bot                                       |
   |`compute`   |      get what the medianizer value would be if updated     |
   |`expires`   |      get expiration in seconds (< 0 means expired)         |
@@ -41,14 +44,14 @@
   |`poke`      |      poke a medianizer                                     |
   |`poker`     |      update a poker                                        |
   |`post`      |      update a ds-price                                     |
-  |`price`     |      show ETH/USD price from \<source>                     |
+  |`price`     |      show ETH/USD price from `<source>`                    |
   |`prod`      |      update a ds-cache                                     |
   |`read`      |      read a dsvalue, dscache or medianizer                 |
   |`set`       |      set next feed of a medianizer                         |
   |`spread`    |      variance of 2 values in %                             |
   |`valid`     |      check if a dsvalue, dscache or medianizer has a value |
   |`void`      |      invalidate a feed                                     |
-  |`volume`    |      show ETH/USD volume from <source>                     |
+  |`volume`    |      show ETH/USD volume from `<source>`                   |
 
 # OPTIONS
    You can provide any `seth` option to commands that send transactions.  

--- a/README.md
+++ b/README.md
@@ -16,23 +16,26 @@
    jshon(1)        https://github.com/mbrock/jshon/
 
 # COMMANDS
-   `average`|         get average price of 2 or more price <source>  
-   `bot`             really cool bot  
-   `compute`         get what the medianizer value would be if updated  
-   `expires`         get expiration in seconds (< 0 means expired)  
-   `help`            print help about setzer(1) or one of its subcommands  
-   `peek`            peek a dsvalue, dscache or medianizer  
-   `poke`            poke a medianizer  
-   `poker`           update a poker  
-   `post`            update a ds-price  
-   `price`           show ETH/USD price from <source>  
-   `prod`            update a ds-cache  
-   `read`            read a dsvalue, dscache or medianizer  
-   `set`             set next feed of a medianizer  
-   `spread`          variance of 2 values in %  
-   `valid`           check if a dsvalue, dscache or medianizer has a value  
-   `void`            invalidate a feed  
-   `volume`          show ETH/USD volume from <source>  
+
+  | command    |     description                                            |
+  |------------|------------------------------------------------------------|
+  |`average`   |      get average price of 2 or more price \<source>        |
+  |`bot`       |      really cool bot                                       |
+  |`compute`   |      get what the medianizer value would be if updated     |
+  |`expires`   |      get expiration in seconds (< 0 means expired)         |
+  |`help`      |      print help about setzer(1) or one of its subcommands  |
+  |`peek`      |      peek a dsvalue, dscache or medianizer                 |
+  |`poke`      |      poke a medianizer                                     |
+  |`poker`     |      update a poker                                        |
+  |`post`      |      update a ds-price                                     |
+  |`price`     |      show ETH/USD price from \<source>                     |
+  |`prod`      |      update a ds-cache                                     |
+  |`read`      |      read a dsvalue, dscache or medianizer                 |
+  |`set`       |      set next feed of a medianizer                         |
+  |`spread`    |      variance of 2 values in %                             |
+  |`valid`     |      check if a dsvalue, dscache or medianizer has a value |
+  |`void`      |      invalidate a feed                                     |
+  |`volume`    |      show ETH/USD volume from <source>                     |
 
 # OPTIONS
    You can provide any `seth` option to commands that send transactions.  

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
    setzer -- manipulate feeds and update data
 
 # SYNOPSIS
-   setzer \<command> [\<args>]  
-   setzer \<command> --help
+   `setzer <command> [<args>]`  
+   `setzer <command> --help`
 
 # INSTALLATION
-   make link       install setzer(1) into /usr/local  
-   make uninstall  uninstall setzer(1) from /usr/local
+   `make link`       install setzer(1) into /usr/local  
+   `make uninstall`  uninstall setzer(1) from /usr/local
 
 # DEPENDENCIES
    seth(1)         https://github.com/dapphub/seth  
@@ -15,23 +15,23 @@
    jshon(1)        https://github.com/mbrock/jshon/
 
 # COMMANDS
-   average         get average price of 2 or more price <source>  
-   bot             really cool bot  
-   compute         get what the medianizer value would be if updated  
-   expires         get expiration in seconds (< 0 means expired)  
-   help            print help about setzer(1) or one of its subcommands  
-   peek            peek a dsvalue, dscache or medianizer  
-   poke            poke a medianizer  
-   poker           update a poker  
-   post            update a ds-price  
-   price           show ETH/USD price from <source>  
-   prod            update a ds-cache  
-   read            read a dsvalue, dscache or medianizer  
-   set             set next feed of a medianizer  
-   spread          variance of 2 values in %  
-   valid           check if a dsvalue, dscache or medianizer has a value  
-   void            invalidate a feed  
-   volume          show ETH/USD volume from <source>  
+   `average`         get average price of 2 or more price <source>  
+   `bot`             really cool bot  
+   `compute`         get what the medianizer value would be if updated  
+   `expires`         get expiration in seconds (< 0 means expired)  
+   `help`            print help about setzer(1) or one of its subcommands  
+   `peek`            peek a dsvalue, dscache or medianizer  
+   `poke`            poke a medianizer  
+   `poker`           update a poker  
+   `post`            update a ds-price  
+   `price`           show ETH/USD price from <source>  
+   `prod`            update a ds-cache  
+   `read`            read a dsvalue, dscache or medianizer  
+   `set`             set next feed of a medianizer  
+   `spread`          variance of 2 values in %  
+   `valid`           check if a dsvalue, dscache or medianizer has a value  
+   `void`            invalidate a feed  
+   `volume`          show ETH/USD volume from <source>  
 
 # OPTIONS
    You can provide any `seth` option to commands that send transactions.  

--- a/README.md
+++ b/README.md
@@ -5,38 +5,6 @@
    `setzer <command> [<args>]`  
    `setzer <command> --help`
 
-# INSTALLATION
-
-   |                |                                        |
-   |----------------|----------------------------------------| 
-   |`make link`     |  install setzer(1) into `/usr/local`   |  
-   |`make uninstall`|  uninstall setzer(1) from `/usr/local` |
-
-# SETUP
-  setzer expects a `/etc/setzer.conf` file that looks like this:
-
-```bash
-  export ETH_FROM="YOUR ACCOUNT"
-  export SETZER_FEED="YOUR PRICE-FEED ADDRESS"
-  export SETZER_MEDIANIZER="0x729D19f657BD0614b4985Cf1D82531c67569197B"
-  
-  #The list of price sources. Execute 'setzer price'
-  export SETZER_SOURCES="LIST OF PRICE SOURCES"
-  
-  #setzer can connect to multiple nodes listed here
-  #Space separated list of nodes' rpc ports to connect to
-  #default 8545
-  export RPC_PORTS="8545"
-  
-  #Time to wait for a node to respond
-  #defaults to 15s
-  export RPC_TIMEOUT=15s
-```
-# DEPENDENCIES
-   seth(1)         https://github.com/dapphub/seth  
-   curl(1)         https://curl.haxx.se/  
-   jshon(1)        https://github.com/mbrock/jshon/
-
 # COMMANDS
 
   | command    |      description                                           |
@@ -58,6 +26,64 @@
   |`valid`     |      check if a dsvalue, dscache or medianizer has a value |
   |`void`      |      invalidate a feed                                     |
   |`volume`    |      show ETH/USD volume from `<source>`                   |
+
+
+# INSTALLATION
+
+   |                |                                        |
+   |----------------|----------------------------------------| 
+   |`make link`     |  install setzer(1) into `/usr/local`   |  
+   |`make uninstall`|  uninstall setzer(1) from `/usr/local` |
+
+# SETUP
+  setzer expects a `/etc/setzer.conf` file that looks like this:
+
+```bash
+  export ETH_FROM="YOUR ACCOUNT"
+  export SETZER_FEED="YOUR PRICE-FEED ADDRESS"
+  export SETZER_MEDIANIZER="0x729D19f657BD0614b4985Cf1D82531c67569197B"
+  
+  #The list of price sources. Execute `setzer price` to get list of valid values!
+  export SETZER_SOURCES="LIST OF PRICE SOURCES"
+  
+  #setzer tries to create a price update transaction with increasing gas price to 
+  #make sure it gets mined. Starts fom $SETZER_INITIAL_GAS_PRICE with $SETZER_GAS_PRICE_INCREMENT 
+  #until $SETZER_MAX_GAS_PRICE. 
+ 
+  #initial gas price in Wei
+  export SETZER_INITIAL_GAS_PRICE=`seth --to-wei 1 gwei`
+  
+  #gas price increment in Wei
+  export SETZER_GAS_PRICE_INCREMENT=`seth --to-wei 5 gwei`
+  
+  #max gas price in Wei
+  export SETZER_MAX_GAS_PRICE=`seth --to-wei 26 gwei`
+  
+  #spread between current price and last price update price in percentage
+  export SETZER_SPREAD=1
+
+  #Seconds to wait between two price fetches
+  export SETZER_INTERVAL_SECONDS=60
+
+  #Seconds to wait for price update transaction to execute on blockchain
+  export SETZER_WAIT_FOR_RESEND=90
+  
+  #auto mode 
+  export SETZER_AUTO=1
+
+  #setzer can connect to multiple nodes listed here
+  #Space separated list of nodes' rpc ports to connect to
+  #default 8545
+  export RPC_PORTS="8545"
+  
+  #Time to wait for a node to respond
+  #default 15s
+  export RPC_TIMEOUT=15s
+```
+# DEPENDENCIES
+   seth(1)         https://github.com/dapphub/seth  
+   curl(1)         https://curl.haxx.se/  
+   jshon(1)        https://github.com/mbrock/jshon/
 
 # OPTIONS
    You can provide any `seth` option to commands that send transactions.  

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
   export SETZER_SOURCES="LIST OF PRICE SOURCES"
   
   #setzer tries to create a price update transaction with increasing gas price to 
-  #make sure it gets mined. Starts fom $SETZER_INITIAL_GAS_PRICE with $SETZER_GAS_PRICE_INCREMENT 
+  #make sure it gets mined. Starts from $SETZER_INITIAL_GAS_PRICE with $SETZER_GAS_PRICE_INCREMENT 
   #until $SETZER_MAX_GAS_PRICE. 
  
   #initial gas price in Wei
@@ -59,16 +59,19 @@
   #max gas price in Wei
   export SETZER_MAX_GAS_PRICE=`seth --to-wei 26 gwei`
   
-  #spread between current price and last price update price in percentage
+  #spread between current price and last update price in percentage
   export SETZER_SPREAD=1
 
   #Seconds to wait between two price fetches
   export SETZER_INTERVAL_SECONDS=60
 
   #Seconds to wait for price update transaction to execute on blockchain
+  # before retrying with higher gas price
   export SETZER_WAIT_FOR_RESEND=90
   
-  #auto mode 
+  #automatically update price if needed
+  # if set to 1 price will be auto updated if needed on the blockchain
+  # if set to '' (empty) price feed will update only if user enters 'y' 
   export SETZER_AUTO=1
 
   #setzer can connect to multiple nodes listed here

--- a/libexec/setzer/setzer-bot
+++ b/libexec/setzer/setzer-bot
@@ -61,11 +61,12 @@ fi
 # Check if connected to node
 for PORT in ${RPC_PORTS:-8545}; do
   export ETH_RPC_PORT=$PORT
-  syncing=$(timeout $RPC_TIMEOUT seth rpc eth_syncing 2> /dev/null)
-  peers=$(timeout $RPC_TIMEOUT seth rpc net_peerCount 2> /dev/null)
-  blockNumber=$(timeout $RPC_TIMEOUT seth block latest number 2> /dev/null || true)
-  sanity=($(timeout $RPC_TIMEOUT setzer peek "$SETZER_FEED" 2> /dev/null || true))
-  [[ $syncing == "false" ]] && [[ $peers -gt 0 ]] && [[ $blockNumber -gt 0 ]] && [[ $sanity ]] && running_client=1  && break 
+  syncing=$(timeout $RPC_TIMEOUT seth rpc eth_syncing 2> /dev/null) \
+	  && peers=$(timeout $RPC_TIMEOUT seth rpc net_peerCount 2> /dev/null) \
+	  && blockNumber=$(timeout $RPC_TIMEOUT seth block latest number 2> /dev/null || true) \
+	  && sanity=($(timeout $RPC_TIMEOUT setzer peek "$SETZER_FEED" 2> /dev/null || true))
+  [[ $syncing == "false" ]] && [[ $peers -gt 0 ]] && [[ $blockNumber -gt 0 ]] && [[ $sanity ]] \
+	  && running_client=1  && break 
 done
 
 if [ "${running_client:-0}" -ne 1 ]; then
@@ -73,6 +74,7 @@ if [ "${running_client:-0}" -ne 1 ]; then
  sleep 5
  exec "$0" "$@"
 fi
+log "Node running on RPC port $ETH_RPC_PORT."
 expires=$(setzer expires "$SETZER_FEED")
 log "Expires in `setzer --format "$expires"`"
 if [ "$expires" -lt 3600 ]; then

--- a/libexec/setzer/setzer-bot
+++ b/libexec/setzer/setzer-bot
@@ -59,12 +59,20 @@ if ! [[ $SETZER_BOT_INIT ]]; then
 fi
 
 # Check if connected to node
-syncing=$(seth rpc eth_syncing 2> /dev/null)
-peers=$(seth rpc net_peerCount 2> /dev/null)
-blockNumber=$(seth block latest number 2> /dev/null || true)
-sanity=($(setzer peek "$SETZER_FEED" 2> /dev/null || true))
-[[ $syncing == "false" ]] && [[ $peers -gt 0 ]] && [[ $blockNumber -gt 0 ]] && [[ $sanity ]] || { log "Not connected to Ethereum, retry in 5 seconds..."; sleep 5; exec "$0" "$@"; }
+for PORT in ${RPC_PORTS:-8545}; do
+  export ETH_RPC_PORT=$PORT
+  syncing=$(timeout $RPC_TIMEOUT seth rpc eth_syncing 2> /dev/null)
+  peers=$(timeout $RPC_TIMEOUT seth rpc net_peerCount 2> /dev/null)
+  blockNumber=$(timeout $RPC_TIMEOUT seth block latest number 2> /dev/null || true)
+  sanity=($(timeout $RPC_TIMEOUT setzer peek "$SETZER_FEED" 2> /dev/null || true))
+  [[ $syncing == "false" ]] && [[ $peers -gt 0 ]] && [[ $blockNumber -gt 0 ]] && [[ $sanity ]] && running_client=1  && break 
+done
 
+if [ "${running_client:-0}" -ne 1 ]; then
+ log "Not connected to Ethereum, retry in 5 seconds..."
+ sleep 5
+ exec "$0" "$@"
+fi
 expires=$(setzer expires "$SETZER_FEED")
 log "Expires in `setzer --format "$expires"`"
 if [ "$expires" -lt 3600 ]; then

--- a/libexec/setzer/setzer-bot
+++ b/libexec/setzer/setzer-bot
@@ -52,8 +52,8 @@ if ! [[ $SETZER_BOT_INIT ]]; then
   # Gas stuff
 
   [[ $SETZER_INITIAL_GAS_PRICE ]] || export SETZER_INITIAL_GAS_PRICE=`seth --to-wei 1 gwei`
-  [[ $SETZER_GAS_PRICE_INCREMENT ]] || export SETZER_GAS_PRICE_INCREMENT=`seth --to-wei 1 gwei`
-  [[ $SETZER_MAX_GAS_PRICE ]] || export SETZER_MAX_GAS_PRICE=`seth --to-wei 10 gwei`
+  [[ $SETZER_GAS_PRICE_INCREMENT ]] || export SETZER_GAS_PRICE_INCREMENT=`seth --to-wei 5 gwei`
+  [[ $SETZER_MAX_GAS_PRICE ]] || export SETZER_MAX_GAS_PRICE=`seth --to-wei 26 gwei`
   
   # TODO: these should be automatic
   export ETH_GAS_PRICE=$SETZER_INITIAL_GAS_PRICE

--- a/libexec/setzer/setzer-bot
+++ b/libexec/setzer/setzer-bot
@@ -78,8 +78,10 @@ if ! [[ $SETZER_BOT_INIT ]]; then
 fi
 
 # Check if connected to node
+export RPC_TIMEOUT=${RPC_TIMEOUT:-15s}
 for PORT in ${RPC_PORTS:-8545}; do
   export ETH_RPC_PORT=$PORT
+  log "Trying on rpc port $ETH_RPC_PORT."
   syncing=$(timeout $RPC_TIMEOUT seth rpc eth_syncing 2> /dev/null) \
 	  && peers=$(timeout $RPC_TIMEOUT seth rpc net_peerCount 2> /dev/null) \
 	  && blockNumber=$(timeout $RPC_TIMEOUT seth block latest number 2> /dev/null || true) \

--- a/setzer-bot.service
+++ b/setzer-bot.service
@@ -4,7 +4,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/setzer bot --auto --gas-start 2000000000 --gas-inc 1000000000 --gas-max  25000000000
+ExecStart=/usr/local/bin/setzer bot --auto
 
 [Install]
 WantedBy=multi-user.target

--- a/setzer-bot.service
+++ b/setzer-bot.service
@@ -4,7 +4,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/setzer bot --auto
+ExecStart=/usr/local/bin/setzer bot --auto --gas-start 2000000000 --gas-inc 1000000000 --gas-max  25000000000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Two changes are here:
- enabling setzer to cycle through multiple ports (using`RPC_PORTS` variable in `/etc/setzer.conf`)
    - setzer is not stuck even if node accepts connection, but does not answer. In cases like this `RPC_TIMEOUT` variable is used to set timeout.
- updated README to Markdown format. Added desc. of new features.
