### PR TITLE
Allow support for busybox in setzer-connected timeout period

### DIFF
--- a/libexec/setzer/setzer-connected
+++ b/libexec/setzer/setzer-connected
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
+
 set -e
+
+# check to see if timeout is from busybox
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+    busytimeflag="-t"
+else
+    busytimeflag=""
+fi
+
 now=$(date +%s)
-timestamp=$(timeout seth block latest timestamp 2>/dev/null || echo 0)
+timeout="10"
+timestamp=$(timeout $busytimeflag $timeout seth block latest timestamp 2>/dev/null || echo 0)
 valid=$(echo "$now" - "$timestamp" | bc)
 [[ $valid -lt 90 ]] || exit 1
 echo true

--- a/libexec/setzer/setzer-connected
+++ b/libexec/setzer/setzer-connected
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -e
-timeout=10s
 now=$(date +%s)
-timestamp=$(timeout "$timeout" seth block latest timestamp 2>/dev/null || echo 0)
+timestamp=$(timeout seth block latest timestamp 2>/dev/null || echo 0)
 valid=$(echo "$now" - "$timestamp" | bc)
 [[ $valid -lt 90 ]] || exit 1
 echo true

--- a/libexec/setzer/setzer-price-magic
+++ b/libexec/setzer/setzer-price-magic
@@ -2,10 +2,18 @@
 set -e
 export LC_NUMERIC=C
 
+# check to see if timeout is from busybox
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+    busytimeflag="-t"
+else
+    busytimeflag=""
+fi
+
 sources="gdax gemini kraken bitstamp bitfinex"
 
 price () {
-  price+=($(timeout 5 setzer price "$1" 2> /dev/null || true))
+  price+=($(timeout $busytimeflag 5 setzer price "$1" 2> /dev/null || true))
 }
 
 for x in $sources; do


### PR DESCRIPTION
This argument breaks support for the version of `timeout` that BusyBox uses (which uses a -t option and doesn't support using the letter 's' in the timeout value)

This solution checks if the version of `timeout` is from BusyBox and adds the `-t` param if so.

This is useful because I'm running `setzer` inside the `nix` Docker image which is based on alpine linux.