### PR TITLE
Change to oasis api v2

### DIFF
--- a/libexec/setzer/setzer-price-mkr-oasis
+++ b/libexec/setzer/setzer-price-mkr-oasis
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
-json=$(curl --request GET --url https://api.oasisdex.com/v2/markets/mkr/dai)
+json=$(curl -sS "https://api.oasisdex.com/v2/markets/mkr/dai")
 price=$(jshon <<<"$json" -e data -e price -u)
 echo $price

--- a/libexec/setzer/setzer-price-mkr-oasis
+++ b/libexec/setzer/setzer-price-mkr-oasis
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
-json=$(curl -sS "http://api.oasisdex.com/v1/markets/mkr/dai")
+json=$(curl --request GET --url https://api.oasisdex.com/v2/markets/mkr/dai)
 price=$(jshon <<<"$json" -e data -e price -u)
 echo $price

--- a/libexec/setzer/setzer-price-mkr-oasis-v1-dep
+++ b/libexec/setzer/setzer-price-mkr-oasis-v1-dep
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+echo "--- WARNING: V1 of the Oasis API is depricated. Please switch to `setzer price mkr-oasis` to use V2 ---"
+json=$(curl -sS "https://api.oasisdex.com/v1/markets/mkr/dai")
+price=$(jshon <<<"$json" -e data -e price -u)
+echo $price


### PR DESCRIPTION
Setzer is currently pulling from Oasis-API version 1. This updates the main MKR-Oasis price to pull from Oasis-API version 2, but preserves (with a deprecated warning) the ability to call v1 using `setzer price mkr-oasis-v1-dep`. 