### PR TITLE
connect to multiple nodes on different ports and urls

### DIFF
--- a/libexec/setzer/setzer-bot
+++ b/libexec/setzer/setzer-bot
@@ -43,10 +43,27 @@ if [[ -e $SETZER_CONF ]]; then
 fi
 
 # check we're connected to ethereum
-while [ "$(setzer connected)" != "true" ]; do
-  log "Not connected to Ethereum, retry in 10 seconds..."
-  sleep 10
+unset ETH_RPC_URL
+while [[ "$(setzer connected)" != "true" ]]; do
+  unset ETH_RPC_URL
+  for port in ${RPC_PORTS:-8545}; do
+    export ETH_RPC_PORT=$port
+    log "Trying on rpc port $ETH_RPC_PORT."
+    [[ "$(setzer connected)" == "true" ]] && ok=true && break
+  done
+  if [[ "$ok" != "true" ]]; then
+                for url in $RPC_URLS; do
+                        export ETH_RPC_URL=$url
+                        log "Trying on rpc url $ETH_RPC_URL"
+                        [[ "$(setzer connected)" == "true" ]] && break && url_ok=true
+                done
+                [[ "$ok" == "true" ]] && unset ETH_RPC_URL
+                [[ "$url_ok" == "true" ]] && ok=true
+  fi
+  [[ "$ok" != "true" ]] && log "Not connected to Ethereum, retry in 10 seconds..." && sleep 10
 done
+[[ -z "$ETH_RPC_URL" ]] && log "Node running on rpc port ${ETH_RPC_PORT:-8545}."
+[[ -n "$ETH_RPC_URL" ]] && log "Node running on rpc url $ETH_RPC_URL."
 
 [[ $ETH_FROM ]] || errors+=("No default account set. Please set it via ETH_FROM ")
 [[ $SETZER_FEED ]] || errors+=("No price feed set. Please set it via SETZER_FEED ")

--- a/libexec/setzer/setzer-connected
+++ b/libexec/setzer/setzer-connected
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
-timeout=10s
+timeout=${RPC_TIMEOUT:-10s}
 now=$(date +%s)
 timestamp=$(timeout "$timeout" seth block latest timestamp 2>/dev/null || echo 0)
 valid=$(echo "$now" - "$timestamp" | bc)
-[[ $valid -lt 120 ]] || exit 1
+[[ $valid -lt ${LATEST_BLOCK_TIMEOUT:-120} ]] || exit 1
 echo true

--- a/libexec/setzer/setzer-price-poly-cmc
+++ b/libexec/setzer/setzer-price-poly-cmc
@@ -7,12 +7,12 @@ if [[ -e /etc/setzer.conf ]]; then
 	#verbose "Imported configuration from /etc/setzer.conf"
 fi
 
-
-# Global configuration
-if [[ -e /etc/setzer.conf ]]; then
+# Local configuration (via -C or --config)
+# Useful for running multiple bots on one box
+if [[ -e $SETZER_CONF ]]; then
 	# shellcheck source=/dev/null
-	. "/etc/setzer.conf"
-	#verbose "Imported configuration from /etc/setzer.conf"
+	. "$SETZER_CONF"
+	#verbose "Imported configuration from $SETZER_CONF"
 fi
 
 set -e

--- a/libexec/setzer/setzer-price-poly-cmc
+++ b/libexec/setzer/setzer-price-poly-cmc
@@ -7,6 +7,14 @@ if [[ -e /etc/setzer.conf ]]; then
 	#verbose "Imported configuration from /etc/setzer.conf"
 fi
 
+
+# Global configuration
+if [[ -e /etc/setzer.conf ]]; then
+	# shellcheck source=/dev/null
+	. "/etc/setzer.conf"
+	#verbose "Imported configuration from /etc/setzer.conf"
+fi
+
 set -e
 json=$(curl -sS -H "X-CMC_PRO_API_KEY:  $CMC_API_KEY" -H "Accept: application/json" -d  "id=2496" -G https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest)
 price=$(jshon <<<"$json" -e data -e 2496 -e quote -e USD -e price -u)

--- a/libexec/setzer/setzer-price-poly-cmc
+++ b/libexec/setzer/setzer-price-poly-cmc
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Global configuration
+if [[ -e /etc/setzer.conf ]]; then
+	# shellcheck source=/dev/null
+	. "/etc/setzer.conf"
+	#verbose "Imported configuration from /etc/setzer.conf"
+fi
+
 set -e
 json=$(curl -sS -H "X-CMC_PRO_API_KEY:  $CMC_API_KEY" -H "Accept: application/json" -d  "id=2496" -G https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest)
 price=$(jshon <<<"$json" -e data -e 2496 -e quote -e USD -e price -u)

--- a/libexec/setzer/setzer-price-rep-cmc
+++ b/libexec/setzer/setzer-price-rep-cmc
@@ -8,6 +8,13 @@ if [[ -e /etc/setzer.conf ]]; then
 	#verbose "Imported configuration from /etc/setzer.conf"
 fi
 
+# Global configuration
+if [[ -e /etc/setzer.conf ]]; then
+	# shellcheck source=/dev/null
+	. "/etc/setzer.conf"
+	#verbose "Imported configuration from /etc/setzer.conf"
+fi
+
 json=$(curl -sS -H "X-CMC_PRO_API_KEY:  $CMC_API_KEY" -H "Accept: application/json" -d  "id=1104" -G https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest)
 price=$(jshon <<<"$json" -e data -e 1104 -e quote -e USD -e price -u)
 echo "$price"

--- a/libexec/setzer/setzer-price-rep-cmc
+++ b/libexec/setzer/setzer-price-rep-cmc
@@ -8,11 +8,12 @@ if [[ -e /etc/setzer.conf ]]; then
 	#verbose "Imported configuration from /etc/setzer.conf"
 fi
 
-# Global configuration
-if [[ -e /etc/setzer.conf ]]; then
+# Local configuration (via -C or --config)
+# Useful for running multiple bots on one box
+if [[ -e $SETZER_CONF ]]; then
 	# shellcheck source=/dev/null
-	. "/etc/setzer.conf"
-	#verbose "Imported configuration from /etc/setzer.conf"
+	. "$SETZER_CONF"
+	#verbose "Imported configuration from $SETZER_CONF"
 fi
 
 json=$(curl -sS -H "X-CMC_PRO_API_KEY:  $CMC_API_KEY" -H "Accept: application/json" -d  "id=1104" -G https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest)

--- a/libexec/setzer/setzer-price-rep-cmc
+++ b/libexec/setzer/setzer-price-rep-cmc
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 set -e
+
+# Global configuration
+if [[ -e /etc/setzer.conf ]]; then
+	# shellcheck source=/dev/null
+	. "/etc/setzer.conf"
+	#verbose "Imported configuration from /etc/setzer.conf"
+fi
+
 json=$(curl -sS -H "X-CMC_PRO_API_KEY:  $CMC_API_KEY" -H "Accept: application/json" -d  "id=1104" -G https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest)
 price=$(jshon <<<"$json" -e data -e 1104 -e quote -e USD -e price -u)
 echo "$price"


### PR DESCRIPTION
With this modification setzer can connect to multiple nodes. When it can not connect to first, it connects to the next, and so on...
First it tries to check all the ports listed (space separated list of) $RPC_PORTS, if none of them operational, it checks all the (space separated url-s in) $RPC_URLS.  (Both of these variables must be set in /etc/setzer.conf.)
This way setzer can become very reliable as failure only happens if ALL the configured nodes fail.
If all your nodes are 70% operational (quite bad reliability) but you have 4 of them your failure chance is .3^4 = 0.81% so your availability is 99.19% !!!!
This way even unreliable nodes (like geth and parity light clients ) can add up to your reliability as including them increases your reliability.

Anyway enjoy!
